### PR TITLE
修复获取仓位失败被误认为手动平仓

### DIFF
--- a/chua_bitget.py
+++ b/chua_bitget.py
@@ -113,10 +113,10 @@ class MultiAssetTradingBot:
     def fetch_positions(self):
         try:
             positions = self.exchange.fetch_positions()
-            return positions
+            return positions, True
         except Exception as e:
             self.logger.error(f"Error fetching positions: {e}")
-            return []
+            return [], False
 
     def close_position(self, symbol, side):
         try:
@@ -139,7 +139,10 @@ class MultiAssetTradingBot:
             return False
 
     def monitor_positions(self):
-        positions = self.fetch_positions()
+        positions, success = self.fetch_positions()
+        if not success:
+            return
+            
         current_symbols = set(position['symbol'] for position in positions if float(position['contracts']) != 0)
 
         closed_symbols = self.detected_positions - current_symbols

--- a/chua_bn.py
+++ b/chua_bn.py
@@ -91,10 +91,10 @@ class MultiAssetTradingBot:
     def fetch_positions(self):
         try:
             positions = self.exchange.fetch_positions()
-            return positions
+            return positions, True
         except Exception as e:
             self.logger.error(f"Error fetching positions: {e}")
-            return []
+            return [], False
 
     def close_position(self, symbol, amount, side):
         try:
@@ -112,7 +112,10 @@ class MultiAssetTradingBot:
 
     def monitor_positions(self):
         print()  # 输出一个空行，便于阅读日志
-        positions = self.fetch_positions()
+        positions, success = self.fetch_positions()
+        if not success:
+            return
+            
         for position in positions:
             symbol = position['symbol']
             position_amt = float(position['info']['positionAmt'])  # 使用 positionAmt 来获取仓位数量

--- a/chua_ok.py
+++ b/chua_ok.py
@@ -105,10 +105,10 @@ class MultiAssetTradingBot:
     def fetch_positions(self):
         try:
             positions = self.exchange.fetch_positions()
-            return positions
+            return positions, True
         except Exception as e:
             self.logger.error(f"Error fetching positions: {e}")
-            return []
+            return [], False
 
     def close_position(self, symbol, amount, side, td_mode):
         try:
@@ -139,7 +139,10 @@ class MultiAssetTradingBot:
             return False
 
     def monitor_positions(self):
-        positions = self.fetch_positions()
+        positions, success = self.fetch_positions()
+        if not success:
+            return
+            
         current_symbols = set(position['symbol'] for position in positions if float(position['contracts']) != 0)
 
         closed_symbols = self.detected_positions - current_symbols

--- a/chua_ok_bot.py
+++ b/chua_ok_bot.py
@@ -123,10 +123,10 @@ class MultiAssetTradingBot:
                     }
                     all_positions.append(position)
 
-            return all_positions
+            return all_positions, True
         except Exception as e:
             self.logger.error(f"Error fetching positions: {e}")
-            return []
+            return [], False
 
     def close_position(self, symbol, amount, side, td_mode, algo_id):
         try:
@@ -150,8 +150,10 @@ class MultiAssetTradingBot:
             return False
 
     def monitor_positions(self):
-
-        positions = self.fetch_positions()
+        positions, success = self.fetch_positions()
+        if not success:
+            return
+            
         current_symbols = set(position['symbol'] for position in positions if float(position['contracts']) != 0)
 
         closed_symbols = self.detected_positions - current_symbols


### PR DESCRIPTION
今天有段时间碰到访问OK的仓位接口有问题：

2024-11-06 14:58:14,411 - __main__ - ERROR - Error fetching positions: okx GET https://www.okx.com/api/v5/account/positions
2024-11-06 14:58:21,446 - __main__ - ERROR - Error fetching positions: okx GET https://www.okx.com/api/v5/account/positions
2024-11-06 14:58:58,687 - __main__ - ERROR - Error fetching positions: okx GET https://www.okx.com/api/v5/account/positions
2024-11-06 14:59:05,718 - __main__ - ERROR - Error fetching positions: okx GET https://www.okx.com/api/v5/account/positions
2024-11-06 14:59:19,541 - __main__ - ERROR - Error fetching positions: okx GET https://www.okx.com/api/v5/account/positions

脚本误认为手动平仓，然后反复横跳，功能没啥影响， 接口访问正常也就恢复了